### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,7 @@ echo -e "${CCYAN}[  EXCLUSION DE FICHIERS/RÉPERTOIRES  ]${CEND}"
 echo -e "${CCYAN}---------------------------------------${CEND}"
 echo ""
 
+touch /opt/full-backup/.excluded-paths
 read -p "Voulez-vous exclure des répertoires de la sauvegarde ? (o/n) : " EXCLUDE
 
 if [[ "$EXCLUDE" = "o" ]] || [[ "$EXCLUDE" = "O" ]]; then


### PR DESCRIPTION
Lors d'une installation du script, le fichier n'est pas crée quand l'utilisateur répond non à la question :  "Voulez-vous exclure des répertoires de la sauvegarde"

Dès lors qu'il voudra réaliser un Backup il obtiendra alors : 
"/!\ ERREUR: Le fichier /opt/full-backup/.excluded-paths n'existe pas !"
